### PR TITLE
Hotfix: Errors/inconsistencies in Sphere class

### DIFF
--- a/adaptive_sampling/sampling_tools/sphere.py
+++ b/adaptive_sampling/sampling_tools/sphere.py
@@ -75,51 +75,53 @@ class Sphere():
         # current time in fs, shifted by t_shift
         t = md_state.step * md_state.dt - self.t_shift
         
-        # update radius based on confinement method
-        if self.confinement_method == "constant" or t < 0.0:
-            self.radius = self.r_max
-        elif self.confinement_method == "step":
-            f = np.heaviside(np.floor(t / (self.t_contract + self.t_expand)) 
-                - t / (self.t_contract + self.t_expand) 
-                + self.t_expand / (self.t_contract + self.t_expand), 0.0)
-            self.radius = f * self.r_max + (1 - f) * self.r_min
-        elif self.confinement_method == "smooth-step":
-            self.radius = np.min([self.r_max + (self.r_max - self.r_min) * np.sin(np.pi/2*np.cos(t/(self.t_expand + self.t_contract)*2*np.pi)) , self.r_max])   
-        elif self.confinement_method == "smooth":
-            self.radius = self.r_min + (self.r_max - self.r_min) * (1e0 + np.cos(t/(self.t_expand + self.t_contract)*2*np.pi))
-
-        # get atom wise confinement forces
-        for i in range(int(md_state.natoms)):
-            xx = md_state.coords[3*i+0]
-            yy = md_state.coords[3*i+1]
-            zz = md_state.coords[3*i+2]
-            r  = np.sqrt(xx*xx+yy*yy+zz*zz)
-            mass = md_state.mass[i]
-
-            if self.confinement_method == "constant" or t < 0.0:
-                if r == 0.e0:
-                    dbase = 0.e0
-                else:
-                    maxr = np.max([0.0,r-self.radius])
-                    self.bias_pot += 0.5e0 * self.k_conf_max * np.power(maxr,2.e0) * mass
-                    dbase = self.k_conf_max * maxr / r * mass
-
+        # takes effect only after t_shift to account for equilibration time before applying confinement
+        if t > 0.0:
+            # update radius based on confinement method
+            if self.confinement_method == "constant":
+                self.radius = self.r_max
             elif self.confinement_method == "step":
-                U_max = mass * self.k_conf_max / 2.e0 * np.power((r - self.r_max),2) * np.heaviside(r - self.r_max, 0.0)
-                U_min = mass * self.k_conf_min / 2.e0 * np.power((r - self.r_min),2) * np.heaviside(r - self.r_min, 0.0)
-                self.bias_pot += f * U_max + (1 - f) * U_min
-                if r == 0.e0:
-                    dbase = 0.e0
-                else:
-                    dbase = (f * self.k_conf_max * mass * (r - self.r_max) / r
-                        + (1. - f) * self.k_conf_min * mass * (r - self.r_min) / r)
+                f = np.heaviside(np.floor(t / (self.t_contract + self.t_expand)) 
+                    - t / (self.t_contract + self.t_expand) 
+                    + self.t_expand / (self.t_contract + self.t_expand), 0.0)
+                self.radius = f * self.r_max + (1 - f) * self.r_min
+            elif self.confinement_method == "smooth-step":
+                self.radius = np.min([self.r_max + (self.r_max - self.r_min) * np.sin(np.pi/2*np.cos(t/(self.t_expand + self.t_contract)*2*np.pi)) , self.r_max])   
+            elif self.confinement_method == "smooth":
+                self.radius = self.r_min + (self.r_max - self.r_min) * (1e0 + np.cos(t/(self.t_expand + self.t_contract)*2*np.pi))
 
-            elif self.confinement_method in ["smooth", "smooth-step"]:
-                dbase = self._calc_dbase(r, mass)
+            # get atom wise confinement forces
+            for i in range(int(md_state.natoms)):
+                xx = md_state.coords[3*i+0]
+                yy = md_state.coords[3*i+1]
+                zz = md_state.coords[3*i+2]
+                r  = np.sqrt(xx*xx+yy*yy+zz*zz)
+                mass = md_state.mass[i]
 
-            bias_force[3*i+0] += dbase * xx
-            bias_force[3*i+1] += dbase * yy
-            bias_force[3*i+2] += dbase * zz
+                if self.confinement_method == "constant":
+                    if r == 0.e0:
+                        dbase = 0.e0
+                    else:
+                        maxr = np.max([0.0,r-self.radius])
+                        self.bias_pot += 0.5e0 * self.k_conf_max * np.power(maxr,2.e0) * mass
+                        dbase = self.k_conf_max * maxr / r * mass
+
+                elif self.confinement_method == "step":
+                    U_max = mass * self.k_conf_max / 2.e0 * np.power((r - self.r_max),2) * np.heaviside(r - self.r_max, 0.0)
+                    U_min = mass * self.k_conf_min / 2.e0 * np.power((r - self.r_min),2) * np.heaviside(r - self.r_min, 0.0)
+                    self.bias_pot += f * U_max + (1 - f) * U_min
+                    if r == 0.e0:
+                        dbase = 0.e0
+                    else:
+                        dbase = (f * self.k_conf_max * mass * (r - self.r_max) / r
+                            + (1. - f) * self.k_conf_min * mass * (r - self.r_min) / r)
+
+                elif self.confinement_method in ["smooth", "smooth-step"]:
+                    dbase = self._calc_dbase(r, mass)
+
+                bias_force[3*i+0] += dbase * xx
+                bias_force[3*i+1] += dbase * yy
+                bias_force[3*i+2] += dbase * zz
         
         return bias_force
 

--- a/adaptive_sampling/sampling_tools/sphere.py
+++ b/adaptive_sampling/sampling_tools/sphere.py
@@ -23,7 +23,7 @@ class Sphere():
         t_period: float = None, 
         t_shift: float = 0.0,
         confinement_method: str = 'smooth-step',
-        diffusion_assisted: bool = False,
+        diffusion_assisted: bool = True,
     ):
         if the_md is None:
             raise ValueError(" >>> ERROR: Molecular dynamics object has to be provided for spherical confinment.")


### PR DESCRIPTION
- Ensure the application of the confinement potential only **after** the **initial/equilibration steps** (i.e., when `t > 0.0`, considering that `t` is already shifted as `t = md_state.step * md_state.dt - self.t_shift` with `t_shift` typically corresponding to the equilibration time period, i.e., `equil_steps * dt`)
- Set `diffusion_assisted` to default value `True` to ensure backwards compatibility with earlier job scripts (in the latest version by @alxstan within the `exploration_tools` branch of this repository the diffusion-related piece of code is hard-coded)